### PR TITLE
MD Version upgrade and proxy enabled

### DIFF
--- a/ubuntu-apache2-mod_md/Dockerfile
+++ b/ubuntu-apache2-mod_md/Dockerfile
@@ -21,15 +21,15 @@ RUN apt-get update --fix-missing && \
 # Install mod_md
 ##############################################################################
 
-ADD https://github.com/icing/mod_md/releases/download/v1.0.3/mod_md-1.0.3.tar.gz /tmp/
+ADD https://github.com/icing/mod_md/releases/download/v1.1.10/mod_md-1.1.10.tar.gz /tmp/
 
 # Needed by `a2enmod md`, thus we copy them before we build mod_md
 COPY etc/apache2/mods-available/md.load /etc/apache2/mods-available/
 COPY etc/apache2/mods-available/md.conf /etc/apache2/mods-available/
 
 RUN cd /tmp/ && \
-    tar -zxvf mod_md-1.0.3.tar.gz && \
-    cd /tmp/mod_md-1.0.3 && \
+    tar -zxvf mod_md-1.1.10.tar.gz && \
+    cd /tmp/mod_md-1.1.10 && \
     ./configure --with-apxs=/usr/bin/apxs && \
     make && \
     make install && \

--- a/ubuntu-apache2-mod_md/Dockerfile
+++ b/ubuntu-apache2-mod_md/Dockerfile
@@ -35,6 +35,11 @@ RUN cd /tmp/ && \
     make install && \
     a2enmod ssl md
 
+# Configure all needed modules
+RUN a2enmod proxy && \
+		a2enmod proxy_http && \
+		a2enmod proxy_http2
+
 ##############################################################################
 # Startup apache2
 ##############################################################################

--- a/ubuntu-apache2-mod_md/Dockerfile
+++ b/ubuntu-apache2-mod_md/Dockerfile
@@ -33,12 +33,7 @@ RUN cd /tmp/ && \
     ./configure --with-apxs=/usr/bin/apxs && \
     make && \
     make install && \
-    a2enmod ssl md
-
-# Configure all needed modules
-RUN a2enmod proxy && \
-		a2enmod proxy_http && \
-		a2enmod proxy_http2
+    a2enmod ssl md proxy proxy_http proxy_http2
 
 ##############################################################################
 # Startup apache2


### PR DESCRIPTION
Hi There,

Great image!
I have updated it a little bit.

Now it runs with the latest MD version (v1.1.10) and is able to handle the ProxyPass tags, so it is now very easy to use as an SSL terminating proxy.

Thanks again for the great image.

/Tue